### PR TITLE
rps lb, subquery rank

### DIFF
--- a/src/commands/features/rps.ts
+++ b/src/commands/features/rps.ts
@@ -1,16 +1,20 @@
-import { Message } from 'discord.js'
+import { GuildMember, Message, MessageEmbed } from 'discord.js'
+import { QueryTypes } from 'sequelize'
+import database from '../../database/database'
 import { guild } from '../../database/models/guild'
 import { rpsGame, rpsGameCreationAttributes } from '../../database/models/rpsGame'
 import { Command } from '../../interfaces'
+import { urlToColours } from '../../utils'
 
 export const command: Command = {
 	name: `rps`,
 	aliases: [],
 	category: `features`,
 	description: `Play Rock, Paper, Scissors with Bento 🍱`,
-	usage: `rps <rock, paper, scissors>`,
+	usage: `rps <rock, paper, scissors> to play the game\nrps stats [user mention or id] to see stats.`,
 	website: `https://www.bentobot.xyz/commands#rps`,
 	run: async (client, message, args): Promise<Message> => {
+		if (args[0] === `stats`) return await userStats(message, args[1])
 		const acceptedReplies = [`rock`, `paper`, `scissors`]
 		const bentoReplies = [`Rock 🪨`, `Paper 🧻`, `Scissors ✂️`]
 		const random = Math.floor(Math.random() * acceptedReplies.length)
@@ -166,6 +170,149 @@ export const command: Command = {
 			default: {
 				return message.channel.send(`Only these responses are accepted: \`${acceptedReplies.join(`, `)}\``)
 			}
+		}
+
+		async function userStats(message: Message, user?: string) {
+			let RPSUser: GuildMember
+			let RPSUserID: string
+
+			if (user) {
+				try {
+					const theUser = message.mentions.members?.has(client.user?.id as string)
+						? message.mentions.members.size > 1
+							? message.mentions.members.last()
+							: message.member
+						: message.mentions.members?.first() || (await message.guild?.members.fetch(user as string))
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					RPSUserID = theUser!.id as string
+					RPSUser = theUser as GuildMember
+				} catch {
+					RPSUserID = message.author.id
+					RPSUser = message.member as GuildMember
+				}
+			} else {
+				RPSUserID = message.author.id
+				RPSUser = message.member as GuildMember
+			}
+
+			const RPSData = await rpsGame.findOne({ raw: true, where: { userID: RPSUserID } })
+
+			if (RPSData === null) return message.channel.send(`Error: This user does not have any stats for the RPS Game.`)
+
+			interface rpsRankings {
+				overallrank: number
+				paperrank: number
+				rockrank: number
+				scissorsrank: number
+			}
+
+			const globalData: Array<rpsRankings> = await database.query(
+				`
+            SELECT overallRank, paperRank, rockRank, scissorsRank
+			FROM (SELECT t.*, row_number() OVER (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC,
+				SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC,
+				SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+			) AS overallRank, row_number() over (ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+			) as paperRank, row_number() over (ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+			) as rockRank, row_number() over (ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+			) as scissorsRank
+				FROM "rpsGame" AS t
+			GROUP BY t."id"
+				) t
+			WHERE "userID" = :user;`,
+				{
+					replacements: { user: RPSUserID as string },
+					type: QueryTypes.SELECT,
+				},
+			)
+
+			const serverData: Array<rpsRankings> = await database.query(
+				`
+            SELECT overallRank, paperRank, rockRank, scissorsRank
+			FROM (SELECT t.*, row_number() OVER (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC,
+				SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC,
+				SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+			) AS overallRank, row_number() over (ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+			) as paperRank, row_number() over (ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+			) as rockRank, row_number() over (ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+			) as scissorsRank
+				FROM "rpsGame" AS t
+			INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+			WHERE gM."guildID" = :guild
+			GROUP BY t."id"
+				) t
+			WHERE "userID" = :user;`,
+				{
+					replacements: { guild: message?.guild?.id as string, user: RPSUserID as string },
+					type: QueryTypes.SELECT,
+				},
+			)
+
+			const userStatsEmbed = new MessageEmbed()
+				.setTitle(
+					`RPS Stats for ${
+						RPSUser.nickname === null ? `${RPSUser.user.username}#${RPSUser.user.discriminator}` : `${RPSUser.nickname}`
+					}`,
+				)
+				.setAuthor(
+					RPSUser.nickname === null ? `${RPSUser.user.username}#${RPSUser.user.discriminator}` : `${RPSUser.nickname}`,
+					RPSUser.user.avatarURL({ dynamic: true }) as string,
+				)
+				.setThumbnail(RPSUser.user.avatarURL({ dynamic: true, size: 1024, format: `png` }) as string)
+				.setColor(`${await urlToColours(RPSUser.user.avatarURL({ format: `png` }) as string)}`)
+				.setTimestamp()
+				.setDescription(
+					`**Overall**\n${Number(RPSData.rockWins) + Number(RPSData.paperWins) + Number(RPSData.scissorWins)} Wins, ${
+						Number(RPSData.rockTies) + Number(RPSData.paperTies) + Number(RPSData.scissorsTies)
+					} Ties, ${
+						Number(RPSData.rockLosses) + Number(RPSData.paperLosses) + Number(RPSData.scissorsLosses)
+					} Losses, Win Rate of ${(
+						winRateCalculation(
+							Number(RPSData.rockWins) + Number(RPSData.paperWins) + Number(RPSData.scissorWins),
+							Number(Number(RPSData.rockWins) + Number(RPSData.paperWins) + Number(RPSData.scissorWins)) +
+								Number(Number(RPSData.rockTies) + Number(RPSData.paperTies) + Number(RPSData.scissorsTies)) +
+								Number(Number(RPSData.rockLosses) + Number(RPSData.paperLosses) + Number(RPSData.scissorsLosses)),
+						) * 100
+					).toFixed(2)}%\nRank ${serverData[0].overallrank} on ${message.guild?.name}, Rank ${
+						globalData[0].overallrank
+					} globally\n\n**Rock**\n${RPSData.rockWins} Wins, ${RPSData.rockTies} Ties, ${
+						RPSData.rockLosses
+					} Losses, Win Rate of ${(
+						winRateCalculation(
+							RPSData.rockWins as number,
+							Number(RPSData.rockWins) + Number(RPSData.rockTies) + Number(RPSData.rockLosses),
+						) * 100
+					).toFixed(2)}%\nRank ${serverData[0].rockrank} on ${message.guild?.name}, Rank ${
+						globalData[0].rockrank
+					} globally\n\n**Paper**\n${RPSData.paperWins} Wins, ${RPSData.paperTies} Ties, ${
+						RPSData.paperLosses
+					} Losses, Win Rate of ${(
+						winRateCalculation(
+							RPSData.paperWins as number,
+							Number(RPSData.paperWins) + Number(RPSData.paperTies) + Number(RPSData.paperLosses),
+						) * 100
+					).toFixed(2)}%\nRank ${serverData[0].paperrank} on ${message.guild?.name}, Rank ${
+						globalData[0].paperrank
+					} globally\n\n**Scissors**\n${RPSData.scissorWins} Wins, ${RPSData.scissorsTies} Ties, ${
+						RPSData.scissorsLosses
+					} Losses, Win Rate of ${(
+						winRateCalculation(
+							RPSData.scissorWins as number,
+							Number(RPSData.scissorWins) + Number(RPSData.scissorsTies) + Number(RPSData.scissorsLosses),
+						) * 100
+					).toFixed(2)}%\nRank ${serverData[0].scissorsrank} on ${message.guild?.name}, Rank ${
+						globalData[0].scissorsrank
+					} globally`,
+				)
+			return message.channel.send(userStatsEmbed)
+		}
+
+		function winRateCalculation(a: number, b: number) {
+			let c = a / b
+			if (isNaN(c)) {
+				c = 0
+			}
+			return c
 		}
 	},
 }

--- a/src/commands/user/leaderboard.ts
+++ b/src/commands/user/leaderboard.ts
@@ -14,12 +14,32 @@ interface Rankings {
 	discriminator?: string
 }
 
+interface rpsGameAttributes {
+	paperWins?: number
+	paperTies?: number
+	paperLosses?: number
+	rockWins?: number
+	rockTies?: number
+	rockLosses?: number
+	scissorWins?: number
+	scissorsLosses?: number
+	scissorsTies?: number
+	id: number
+	userID: bigint
+	rank?: number
+	wins?: number
+	ties?: number
+	losses?: number
+	username?: string
+	discriminator?: string
+}
+
 export const command: Command = {
 	name: `leaderboard`,
 	aliases: [`ranking`, `rankings`, `lb`],
 	category: `user`,
 	description: `Shows the XP/level leaderboard for a server, globally for the bot, or global/local Bentos 🍱`,
-	usage: `leaderboard [<global/bento>] [global]`,
+	usage: `leaderboard [global] to see message/xp leaderboard, where the global argument shows globally for the bot.\nleaderboard bento [global] shows leaderboard for the amount of Bento 🍱 with a global option as well.\nleaderboard rps [paper, rock, scissors, all] [wins, ties, losses] shows the server leaderboard for the RPS game, where it's possible to order by wins, ties and losses. By adding global before rock, paper and scissor, it is then possible to view the global leaderboard.`,
 	website: `https://www.bentobot.xyz/commands#leaderboard`,
 	run: async (client, message, args): Promise<Message | void> => {
 		try {
@@ -37,6 +57,14 @@ export const command: Command = {
 
 			if (args[0] === `bento`) {
 				return bentoServerLeaderboard(message)
+			}
+
+			if (args[0] === `rps`) {
+				if (args[1] === `lb`) return rpsServerLeaderboard(message, args[2], args[3])
+				if (args[1] === `leaderboard`) return rpsServerLeaderboard(message, args[2], args[3])
+				if (args[1] === `global`) return rpsGlobalLeaderboard(message, args[2], args[3])
+				// user, where it's possible to tag a user
+				return rpsServerLeaderboard(message)
 			}
 
 			if (args[0] === `web`) {
@@ -290,6 +318,672 @@ export const command: Command = {
 			}
 		}
 
+		async function rpsServerLeaderboard(message: Message, gameType?: string, order?: string) {
+			try {
+				let rpsGameData: rpsGameAttributes[] | undefined
+				if (order) {
+					const potentialOrders = [`wins`, `losses`, `ties`]
+					if (!potentialOrders.includes(order)) {
+						return message.channel.send(
+							`The listed value you wanted to order by is not valid.\nYou can only order by wins, ties and losses.`,
+						)
+					}
+				}
+				let gameTypeName: string | undefined
+				if (gameType) {
+					if (gameType === `paper`) {
+						gameTypeName = `Paper`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperTies" DESC, t."paperWins" DESC, t."paperLosses" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							ORDER BY t."paperTies" DESC, t."paperWins" DESC, t."paperLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperLosses" DESC, t."paperWins" DESC, t."paperTies" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							ORDER BY t."paperLosses" DESC, t."paperWins" DESC, t."paperTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `rock`) {
+						gameTypeName = `Rock`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockTies" DESC, t."rockWins" DESC, t."rockLosses" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							ORDER BY t."rockTies" DESC, t."rockWins" DESC, t."rockLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockLosses" DESC, t."rockWins" DESC, t."rockTies" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							ORDER BY t."rockLosses" DESC, t."rockWins" DESC, t."rockTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `scissors`) {
+						gameTypeName = `Scissors`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorsTies" DESC, t."scissorWins" DESC, t."scissorsLosses" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							ORDER BY t."scissorsTies" DESC, t."scissorWins" DESC, t."scissorsLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorsLosses" DESC, t."scissorWins" DESC, t."scissorsTies" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							ORDER BY t."scissorsLosses" DESC, t."scissorWins" DESC, t."scissorsTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild AND t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `all`) {
+						gameTypeName = `all`
+						if (order === `wins`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild
+							GROUP BY t."userID"
+							ORDER BY wins DESC, ties DESC, losses DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild
+							GROUP BY t."userID"
+							ORDER BY ties DESC, wins DESC, losses DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC, SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild
+							GROUP BY t."userID"
+							ORDER BY losses DESC, wins DESC, ties DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild
+							GROUP BY t."userID"
+							ORDER BY wins DESC, ties DESC, losses DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+				} else {
+					gameTypeName = `all`
+					rpsGameData = await database.query(
+						`
+							SELECT row_number() over (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses
+							FROM "rpsGame" AS t
+							INNER JOIN "guildMember" gM on t."userID" = gM."userID"
+							WHERE gm."guildID" = :guild
+							GROUP BY t."userID"
+							ORDER BY wins DESC, ties DESC, losses DESC
+							LIMIT 50;`,
+						{
+							replacements: { guild: message?.guild?.id },
+							type: QueryTypes.SELECT,
+						},
+					)
+				}
+
+				if (!rpsGameData?.length) return message.channel.send(`No RPS games has been played on this server.`)
+				let currentPage = 0
+				const embeds = await generateRpsServerLeaderboard(rpsGameData, message, gameTypeName as string, order)
+				const queueEmbed = await message.channel.send(
+					`Current Page: ${currentPage + 1}/${embeds.length}`,
+					embeds[currentPage],
+				)
+				await queueEmbed.react(`⬅️`)
+				await queueEmbed.react(`➡️`)
+				await queueEmbed.react(`❌`)
+				const filter = (reaction: MessageReaction, user: User) =>
+					[`⬅️`, `➡️`, `❌`].includes(reaction.emoji.name) && message.author.id === user.id
+				const collector = queueEmbed.createReactionCollector(filter, {
+					idle: 300000,
+					dispose: true,
+				})
+
+				collector.on(`collect`, async (reaction, user) => {
+					if (reaction.emoji.name === `➡️`) {
+						if (currentPage < embeds.length - 1) {
+							currentPage++
+							reaction.users.remove(user)
+							queueEmbed.edit(`Current Page: ${currentPage + 1}/${embeds.length}`, embeds[currentPage])
+						}
+					} else if (reaction.emoji.name === `⬅️`) {
+						if (currentPage !== 0) {
+							--currentPage
+							reaction.users.remove(user)
+							queueEmbed.edit(`Current Page ${currentPage + 1}/${embeds.length}`, embeds[currentPage])
+						}
+					} else {
+						collector.stop()
+						await queueEmbed.delete()
+					}
+				})
+			} catch (err) {
+				console.log(`Error at leaderboard.ts' serverlb function, server ${message.guild?.id}\n\n${err}`)
+			}
+		}
+
+		async function rpsGlobalLeaderboard(message: Message, gameType?: string, order?: string) {
+			try {
+				let rpsGameData: rpsGameAttributes[] | undefined
+				if (order) {
+					const potentialOrders = [`wins`, `losses`, `ties`]
+					if (!potentialOrders.includes(order)) {
+						return message.channel.send(
+							`The listed value you wanted to order by is not valid.\nYou can only order by wins, ties and losses.`,
+						)
+					}
+				}
+				let gameTypeName: string | undefined
+				if (gameType) {
+					if (gameType === `paper`) {
+						gameTypeName = `Paper`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperTies" DESC, t."paperWins" DESC, t."paperLosses" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."paperWins", t."paperTies", t."paperLosses"
+							ORDER BY t."paperTies" DESC, t."paperWins" DESC, t."paperLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperLosses" DESC, t."paperWins" DESC, t."paperTies" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."paperWins", t."paperTies", t."paperLosses"
+							ORDER BY t."paperLosses" DESC, t."paperWins" DESC, t."paperTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+							) as rank, t."userID", t."paperWins" AS wins, t."paperTies" AS ties, t."paperLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+                            WHERE t."paperWins" + t."paperTies" + t."paperLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."paperWins", t."paperTies", t."paperLosses"
+							ORDER BY t."paperWins" DESC, t."paperTies" DESC, t."paperLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `rock`) {
+						gameTypeName = `Rock`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockTies" DESC, t."rockWins" DESC, t."rockLosses" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."rockWins", t."rockTies", t."rockLosses"
+							ORDER BY t."rockTies" DESC, t."rockWins" DESC, t."rockLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockLosses" DESC, t."rockWins" DESC, t."rockTies" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."rockWins", t."rockTies", t."rockLosses"
+							ORDER BY t."rockLosses" DESC, t."rockWins" DESC, t."rockTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+							) as rank, t."userID", t."rockWins" AS wins, t."rockTies" as ties, t."rockLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."rockWins" + t."rockTies" + t."rockLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."rockWins", t."rockTies", t."rockLosses"
+							ORDER BY t."rockWins" DESC, t."rockTies" DESC, t."rockLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `scissors`) {
+						gameTypeName = `Scissors`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorsTies" DESC, t."scissorWins" DESC, t."scissorsLosses" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."scissorWins", t."scissorsTies", t."scissorsLosses"
+							ORDER BY t."scissorsTies" DESC, t."scissorWins" DESC, t."scissorsLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorsLosses" DESC, t."scissorWins" DESC, t."scissorsTies" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."scissorWins", t."scissorsTies", t."scissorsLosses"
+							ORDER BY t."scissorsLosses" DESC, t."scissorWins" DESC, t."scissorsTies" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+							) as rank, t."userID", t."scissorWins" AS wins, t."scissorsTies" AS ties, t."scissorsLosses" AS losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							WHERE t."scissorWins" + t."scissorsTies" + t."scissorsLosses" != 0
+							GROUP BY t."userID", u.username, u.discriminator, t."scissorWins", t."scissorsTies", t."scissorsLosses"
+							ORDER BY t."scissorWins" DESC, t."scissorsTies" DESC, t."scissorsLosses" DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+					if (gameType === `all`) {
+						gameTypeName = `all`
+						if (order === `ties`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							GROUP BY t."userID", u.username, u.discriminator
+							ORDER BY ties DESC, wins DESC, losses DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else if (order === `losses`) {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC, SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							GROUP BY t."userID", u.username, u.discriminator
+							ORDER BY losses DESC, wins DESC, ties DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						} else {
+							rpsGameData = await database.query(
+								`
+							SELECT row_number() over (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank, t."userID", SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins, SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties, SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							GROUP BY t."userID", u.username, u.discriminator
+							ORDER BY wins DESC, ties DESC, losses DESC
+							LIMIT 50;`,
+								{
+									replacements: { guild: message?.guild?.id },
+									type: QueryTypes.SELECT,
+								},
+							)
+						}
+					}
+				} else {
+					gameTypeName = `all`
+					rpsGameData = await database.query(
+						`
+							SELECT row_number() over (ORDER BY SUM(t."paperWins" + t."rockWins" + t."scissorWins") DESC,
+								SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") DESC,
+								SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") DESC
+							) as rank,
+								t."userID",
+								SUM(t."paperWins" + t."rockWins" + t."scissorWins") as wins,
+								SUM(t."paperTies"+ t."rockTies" + t."scissorsTies") as ties,
+								SUM(t."paperLosses" + t."rockLosses"+ t."scissorsLosses") as losses,
+								u.username, u.discriminator
+							FROM "rpsGame" AS t
+							INNER JOIN "user" u on u."userID" = t."userID"
+							GROUP BY t."userID", u.username, u.discriminator
+							ORDER BY wins DESC, ties DESC, losses DESC
+							LIMIT 50;`,
+						{
+							replacements: { guild: message?.guild?.id },
+							type: QueryTypes.SELECT,
+						},
+					)
+				}
+
+				if (!rpsGameData?.length) return message.channel.send(`No RPS games has been played on this server.`)
+				let currentPage = 0
+				const embeds = await generateRpsGlobalLeaderboard(rpsGameData, message, gameTypeName as string, order)
+				const queueEmbed = await message.channel.send(
+					`Current Page: ${currentPage + 1}/${embeds.length}`,
+					embeds[currentPage],
+				)
+				await queueEmbed.react(`⬅️`)
+				await queueEmbed.react(`➡️`)
+				await queueEmbed.react(`❌`)
+				const filter = (reaction: MessageReaction, user: User) =>
+					[`⬅️`, `➡️`, `❌`].includes(reaction.emoji.name) && message.author.id === user.id
+				const collector = queueEmbed.createReactionCollector(filter, {
+					idle: 300000,
+					dispose: true,
+				})
+
+				collector.on(`collect`, async (reaction, user) => {
+					if (reaction.emoji.name === `➡️`) {
+						if (currentPage < embeds.length - 1) {
+							currentPage++
+							reaction.users.remove(user)
+							queueEmbed.edit(`Current Page: ${currentPage + 1}/${embeds.length}`, embeds[currentPage])
+						}
+					} else if (reaction.emoji.name === `⬅️`) {
+						if (currentPage !== 0) {
+							--currentPage
+							reaction.users.remove(user)
+							queueEmbed.edit(`Current Page ${currentPage + 1}/${embeds.length}`, embeds[currentPage])
+						}
+					} else {
+						collector.stop()
+						await queueEmbed.delete()
+					}
+				})
+			} catch (err) {
+				console.log(`Error at leaderboard.ts' serverlb function, server ${message.guild?.id}\n\n${err}`)
+			}
+		}
+
+		async function generateRpsServerLeaderboard(
+			input: rpsGameAttributes[],
+			message: Message,
+			gameType: string,
+			order?: string,
+		) {
+			const embeds = []
+			let k = 10
+			for (let i = 0; i < input.length; i += 10) {
+				const current = input.slice(i, k)
+				//let j = i;
+				k += 10
+				// det foroven skærer, så det kun bliver 10 pr. page.
+				const embed = new MessageEmbed()
+				embed.setColor(
+					`${
+						message?.guild?.iconURL()
+							? await urlToColours(message?.guild?.iconURL({ format: `png` }) as string)
+							: await urlToColours(client?.user?.avatarURL({ format: `png` }) as string)
+					}`,
+				)
+				embed.setTimestamp()
+				const info = current
+					.map(
+						(user) =>
+							`${user.rank}. ${message.guild?.members.cache.get(`${user.userID}`)}\n${user.wins} Wins, ${
+								user.ties
+							} Ties, ${user.losses} Losses, ${(
+								winRateCalculation(Number(user.wins), Number(user.wins) + Number(user.ties) + Number(user.losses)) * 100
+							).toFixed(2)}% Win Rate`,
+					)
+					.join(`\n`)
+				embed.setDescription(`${order ? `Ordered by __${order}__\n` : ``}${info}`)
+				embed.setTitle(
+					`RPS Leaderboard for ${message?.guild?.name}${gameType === `all` ? `` : `, ranked by ${gameType}`}`,
+				)
+				embed.setThumbnail(
+					message?.guild?.iconURL({ dynamic: true, format: `png` })
+						? (message?.guild?.iconURL({
+								dynamic: true,
+								format: `png`,
+						  }) as string)
+						: (client?.user?.avatarURL() as string),
+				)
+				embeds.push(embed)
+			}
+			return embeds
+		}
+
+		async function generateRpsGlobalLeaderboard(
+			input: rpsGameAttributes[],
+			message: Message,
+			gameType: string,
+			order?: string,
+		) {
+			const embeds = []
+			let k = 10
+			for (let i = 0; i < input.length; i += 10) {
+				const current = input.slice(i, k)
+				//let j = i;
+				k += 10
+				// det foroven skærer, så det kun bliver 10 pr. page.
+				const embed = new MessageEmbed()
+				embed.setColor(`${await urlToColours(client?.user?.avatarURL({ format: `png` }) as string)}`)
+				embed.setTimestamp()
+				const info = current
+					.map(
+						(user) =>
+							`**${user.rank}. ${user.username}#${user.discriminator}**\n${user.wins} Wins, ${user.ties} Ties, ${
+								user.losses
+								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+							} Losses, ${(
+								winRateCalculation(Number(user.wins), Number(user.wins) + Number(user.ties) + Number(user.losses)) * 100
+							).toFixed(2)}% Win Rate`,
+					)
+					.join(`\n`)
+				embed.setDescription(`${order ? `Ordered by __${order}__\n` : ``}${info}`)
+				embed.setTitle(`RPS Leaderboard for Bento 🍱${gameType === `all` ? `` : `, ranked by ${gameType}`}`)
+				embed.setThumbnail(client?.user?.avatarURL() as string)
+				embeds.push(embed)
+			}
+			return embeds
+		}
+
 		async function generateGlobalLBembed(input: Rankings[]) {
 			const embeds = []
 			let k = 10
@@ -408,6 +1102,11 @@ export const command: Command = {
 				embeds.push(embed)
 			}
 			return embeds
+		}
+
+		function winRateCalculation(a: number, b: number) {
+			const c = a / b
+			return c
 		}
 	},
 }


### PR DESCRIPTION
**New features**
- RPS leaderboard under the leaderboard command, with sorting options by wins, ties and losses. Both global and server ofc.
- RPS stats under the RPS command. During this process I discovered the concept of subquerying with SQL, which made it possible to obtain ranks for one user database-side without a for loop on the server side, which created a foundation for the improvement below

**Improvements**

- Improvements to the rank feature by using subqueries instead of for loops server-side